### PR TITLE
feat(todo): 移除任务分类并增强专注快捷完成

### DIFF
--- a/backend/routes/arxiv_routes.py
+++ b/backend/routes/arxiv_routes.py
@@ -1109,14 +1109,13 @@ async def commit_daily_tasks(
                     continue
                 task_row = await conn.fetchrow(
                     """
-                    INSERT INTO tasks(user_id, title, content, category, status, priority, target_duration, start_date, due_date)
-                    VALUES ($1, $2, $3, $4, 'todo', 1, 0, NOW(), NULL)
+                    INSERT INTO tasks(user_id, title, content, status, priority, target_duration, start_date, due_date)
+                    VALUES ($1, $2, $3, 'todo', 1, 0, NOW(), NULL)
                     RETURNING id
                     """,
                     int(user.id),
                     f"[Arxiv] {str(row['title'])}",
                     f"论文摘要要点：\n{str(row['summary'])}",
-                    "arxiv-daily",
                 )
                 if task_row is None:
                     skipped += 1

--- a/backend/routes/todo_routes.py
+++ b/backend/routes/todo_routes.py
@@ -12,16 +12,22 @@ from routes.auth_routes import get_current_user
 
 router = APIRouter(prefix="/todo", tags=["todo"])
 
-TaskStatus = Literal["todo", "doing", "done"]
+TaskStatus = Literal["todo", "done"]
+TaskCyclePeriod = Literal["daily", "weekly", "monthly", "custom"]
 
 
 class TaskCreateRequest(BaseModel):
     title: str = Field(min_length=1, max_length=255)
     content: str | None = None
-    category: str = Field(default="", max_length=50)
     status: TaskStatus = "todo"
     priority: int = Field(default=0, ge=0, le=3)
     target_duration: int = Field(default=0, ge=0)
+    current_cycle_count: int = Field(default=0, ge=0)
+    target_cycle_count: int = Field(default=0, ge=0)
+    cycle_period: TaskCyclePeriod = "daily"
+    cycle_every_days: int | None = Field(default=None, ge=1)
+    event: str = ""
+    tags: list[str] = Field(default_factory=list)
     start_date: datetime | None = None
     due_date: datetime | None = None
 
@@ -29,10 +35,15 @@ class TaskCreateRequest(BaseModel):
 class TaskUpdateRequest(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=255)
     content: str | None = None
-    category: str | None = Field(default=None, max_length=50)
     status: TaskStatus | None = None
     priority: int | None = Field(default=None, ge=0, le=3)
     target_duration: int | None = Field(default=None, ge=0)
+    current_cycle_count: int | None = Field(default=None, ge=0)
+    target_cycle_count: int | None = Field(default=None, ge=0)
+    cycle_period: TaskCyclePeriod | None = None
+    cycle_every_days: int | None = Field(default=None, ge=1)
+    event: str | None = None
+    tags: list[str] | None = None
     start_date: datetime | None = None
     due_date: datetime | None = None
 
@@ -42,10 +53,15 @@ class TaskOut(BaseModel):
     user_id: int
     title: str
     content: str | None
-    category: str
     status: TaskStatus
     priority: int
     target_duration: int
+    current_cycle_count: int
+    target_cycle_count: int
+    cycle_period: TaskCyclePeriod
+    cycle_every_days: int | None
+    event: str
+    tags: list[str]
     actual_duration: int
     start_date: datetime | None
     due_date: datetime | None
@@ -109,24 +125,70 @@ async def init_todo(app: Any) -> None:
               user_id BIGINT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
               title VARCHAR(255) NOT NULL,
               content TEXT NULL,
-              category VARCHAR(50) NOT NULL DEFAULT '',
               status VARCHAR(20) NOT NULL DEFAULT 'todo',
               priority INTEGER NOT NULL DEFAULT 0,
               target_duration INTEGER NOT NULL DEFAULT 0,
+              current_cycle_count INTEGER NOT NULL DEFAULT 0,
+              target_cycle_count INTEGER NOT NULL DEFAULT 0,
+              cycle_period VARCHAR(20) NOT NULL DEFAULT 'daily',
+              cycle_every_days INTEGER NULL,
+              event TEXT NOT NULL DEFAULT '',
+              tags TEXT[] NOT NULL DEFAULT '{}',
               actual_duration INTEGER NOT NULL DEFAULT 0,
               start_date TIMESTAMPTZ NULL,
               due_date TIMESTAMPTZ NULL,
               is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
               created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
               updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-              CONSTRAINT chk_tasks_status CHECK (status IN ('todo', 'doing', 'done')),
+              CONSTRAINT chk_tasks_status CHECK (status IN ('todo', 'done')),
               CONSTRAINT chk_tasks_priority CHECK (priority BETWEEN 0 AND 3),
               CONSTRAINT chk_tasks_target_duration CHECK (target_duration >= 0),
+              CONSTRAINT chk_tasks_current_cycle_count CHECK (current_cycle_count >= 0),
+              CONSTRAINT chk_tasks_target_cycle_count CHECK (target_cycle_count >= 0),
+              CONSTRAINT chk_tasks_cycle_period CHECK (cycle_period IN ('daily', 'weekly', 'monthly', 'custom')),
+              CONSTRAINT chk_tasks_cycle_every_days CHECK (
+                  (cycle_period <> 'custom' AND cycle_every_days IS NULL)
+                  OR
+                  (cycle_period = 'custom' AND cycle_every_days IS NOT NULL AND cycle_every_days >= 1)
+              ),
               CONSTRAINT chk_tasks_actual_duration CHECK (actual_duration >= 0)
             );
             """
         )
         await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS start_date TIMESTAMPTZ NULL;")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS current_cycle_count INTEGER NOT NULL DEFAULT 0;")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS target_cycle_count INTEGER NOT NULL DEFAULT 0;")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS cycle_period VARCHAR(20) NOT NULL DEFAULT 'daily';")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS cycle_every_days INTEGER NULL;")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS event TEXT NOT NULL DEFAULT '';")
+        await conn.execute("ALTER TABLE tasks ADD COLUMN IF NOT EXISTS tags TEXT[] NOT NULL DEFAULT '{}';")
+        await conn.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS category;")
+        await conn.execute("UPDATE tasks SET status = 'todo' WHERE status = 'doing';")
+        await conn.execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS chk_tasks_status;")
+        await conn.execute("ALTER TABLE tasks ADD CONSTRAINT chk_tasks_status CHECK (status IN ('todo', 'done'));")
+        await conn.execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS chk_tasks_current_cycle_count;")
+        await conn.execute(
+            "ALTER TABLE tasks ADD CONSTRAINT chk_tasks_current_cycle_count CHECK (current_cycle_count >= 0);"
+        )
+        await conn.execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS chk_tasks_target_cycle_count;")
+        await conn.execute(
+            "ALTER TABLE tasks ADD CONSTRAINT chk_tasks_target_cycle_count CHECK (target_cycle_count >= 0);"
+        )
+        await conn.execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS chk_tasks_cycle_period;")
+        await conn.execute(
+            "ALTER TABLE tasks ADD CONSTRAINT chk_tasks_cycle_period CHECK (cycle_period IN ('daily', 'weekly', 'monthly', 'custom'));"
+        )
+        await conn.execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS chk_tasks_cycle_every_days;")
+        await conn.execute(
+            """
+            ALTER TABLE tasks
+            ADD CONSTRAINT chk_tasks_cycle_every_days CHECK (
+                (cycle_period <> 'custom' AND cycle_every_days IS NULL)
+                OR
+                (cycle_period = 'custom' AND cycle_every_days IS NOT NULL AND cycle_every_days >= 1)
+            );
+            """
+        )
         await conn.execute(
             """
             CREATE TABLE IF NOT EXISTS focus_logs (
@@ -178,10 +240,15 @@ def _row_to_task(row: asyncpg.Record) -> TaskOut:
         user_id=int(row["user_id"]),
         title=str(row["title"]),
         content=row["content"],
-        category=str(row["category"] or ""),
         status=row["status"],
         priority=int(row["priority"]),
         target_duration=int(row["target_duration"]),
+        current_cycle_count=int(row["current_cycle_count"]),
+        target_cycle_count=int(row["target_cycle_count"]),
+        cycle_period=row["cycle_period"],
+        cycle_every_days=row["cycle_every_days"],
+        event=str(row["event"] or ""),
+        tags=[str(x) for x in (row["tags"] or [])],
         actual_duration=int(row["actual_duration"]),
         start_date=row["start_date"],
         due_date=row["due_date"],
@@ -219,18 +286,28 @@ async def create_task(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            INSERT INTO tasks(user_id, title, content, category, status, priority, target_duration, start_date, due_date)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            RETURNING id, user_id, title, content, category, status, priority, target_duration, actual_duration,
-                      start_date, due_date, is_deleted, created_at, updated_at
+            INSERT INTO tasks(
+                user_id, title, content, status, priority, target_duration,
+                current_cycle_count, target_cycle_count, cycle_period, cycle_every_days, event, tags,
+                start_date, due_date
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            RETURNING id, user_id, title, content, status, priority, target_duration,
+                      current_cycle_count, target_cycle_count, cycle_period, cycle_every_days, event, tags,
+                      actual_duration, start_date, due_date, is_deleted, created_at, updated_at
             """,
             int(user.id),
             body.title,
             body.content,
-            body.category,
             body.status,
             body.priority,
             body.target_duration,
+            body.current_cycle_count,
+            body.target_cycle_count,
+            body.cycle_period,
+            body.cycle_every_days,
+            body.event,
+            body.tags,
             body.start_date,
             body.due_date,
         )
@@ -244,7 +321,6 @@ async def list_tasks(
     request: Request,
     user: Annotated[Any, Depends(get_current_user)],
     status_: Annotated[TaskStatus | None, Query(alias="status")] = None,
-    category: str | None = Query(default=None, max_length=50),
     q: str | None = Query(default=None, max_length=255),
     include_deleted: bool = False,
     limit: int = Query(default=50, ge=1, le=200),
@@ -261,9 +337,6 @@ async def list_tasks(
     if status_ is not None:
         args.append(status_)
         clauses.append(f"status = ${len(args)}")
-    if category is not None and category.strip():
-        args.append(category.strip())
-        clauses.append(f"category = ${len(args)}")
     if q is not None and q.strip():
         args.append(f"%{q.strip()}%")
         clauses.append(f"title ILIKE ${len(args)}")
@@ -275,8 +348,9 @@ async def list_tasks(
 
     where_sql = " AND ".join(clauses)
     sql = f"""
-        SELECT id, user_id, title, content, category, status, priority, target_duration, actual_duration,
-               start_date, due_date, is_deleted, created_at, updated_at
+        SELECT id, user_id, title, content, status, priority, target_duration,
+               current_cycle_count, target_cycle_count, cycle_period, cycle_every_days, event, tags,
+               actual_duration, start_date, due_date, is_deleted, created_at, updated_at
         FROM tasks
         WHERE {where_sql}
         ORDER BY updated_at DESC
@@ -300,8 +374,9 @@ async def get_task(
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT id, user_id, title, content, category, status, priority, target_duration, actual_duration,
-                   start_date, due_date, is_deleted, created_at, updated_at
+            SELECT id, user_id, title, content, status, priority, target_duration,
+                   current_cycle_count, target_cycle_count, cycle_period, cycle_every_days, event, tags,
+                   actual_duration, start_date, due_date, is_deleted, created_at, updated_at
             FROM tasks
             WHERE id = $1 AND user_id = $2 AND ($3::BOOLEAN = TRUE OR is_deleted = FALSE)
             """,
@@ -329,10 +404,15 @@ async def update_task(
     allowed_cols: dict[str, str] = {
         "title": "title",
         "content": "content",
-        "category": "category",
         "status": "status",
         "priority": "priority",
         "target_duration": "target_duration",
+        "current_cycle_count": "current_cycle_count",
+        "target_cycle_count": "target_cycle_count",
+        "cycle_period": "cycle_period",
+        "cycle_every_days": "cycle_every_days",
+        "event": "event",
+        "tags": "tags",
         "start_date": "start_date",
         "due_date": "due_date",
     }
@@ -358,8 +438,9 @@ async def update_task(
         UPDATE tasks
         SET {", ".join(sets)}, updated_at = NOW()
         WHERE id = ${task_i} AND user_id = ${user_i} AND is_deleted = FALSE
-        RETURNING id, user_id, title, content, category, status, priority, target_duration, actual_duration,
-                  start_date, due_date, is_deleted, created_at, updated_at
+        RETURNING id, user_id, title, content, status, priority, target_duration,
+                  current_cycle_count, target_cycle_count, cycle_period, cycle_every_days, event, tags,
+                  actual_duration, start_date, due_date, is_deleted, created_at, updated_at
     """
 
     pool = _pool_from_request(request)

--- a/backend/scripts/todo_selftest.py
+++ b/backend/scripts/todo_selftest.py
@@ -44,7 +44,6 @@ def _run() -> int:
             json={
                 "title": "test task",
                 "content": "hello",
-                "category": "学习",
                 "status": "todo",
                 "priority": 2,
                 "target_duration": 1500,
@@ -68,11 +67,11 @@ def _run() -> int:
             print("task not found in list:", r.text)
             return 1
 
-        r = c.patch("/todo/tasks/" + task_id, headers=headers, json={"status": "doing"})
+        r = c.patch("/todo/tasks/" + task_id, headers=headers, json={"status": "done"})
         if r.status_code != 200:
             print("patch task failed:", r.status_code, r.text)
             return 1
-        if (r.json() or {}).get("status") != "doing":
+        if (r.json() or {}).get("status") != "done":
             print("unexpected status after patch:", r.text)
             return 1
 

--- a/frontend/src/components/PlaceholderCard.tsx
+++ b/frontend/src/components/PlaceholderCard.tsx
@@ -8,10 +8,15 @@ interface Task {
   user_id: number;
   title: string;
   content: string | null;
-  category: string;
-  status: 'todo' | 'doing' | 'done';
+  status: 'todo' | 'done';
   priority: number;
   target_duration: number;
+  current_cycle_count: number;
+  target_cycle_count: number;
+  cycle_period: 'daily' | 'weekly' | 'monthly' | 'custom';
+  cycle_every_days: number | null;
+  event: string;
+  tags: string[];
   actual_duration: number;
   start_date: string | null;
   due_date: string | null;
@@ -51,23 +56,34 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   const [currentFocus, setCurrentFocus] = useState<FocusSession | null>(null);
   const [focusDurationStr, setFocusDurationStr] = useState('0min');
   const [todayFocusMinutes, setTodayFocusMinutes] = useState(0);
+  const [showFocusTaskPicker, setShowFocusTaskPicker] = useState(false);
+  const [focusTargetTaskId, setFocusTargetTaskId] = useState<string | null>(null);
+  const [focusQuickActionBusy, setFocusQuickActionBusy] = useState(false);
 
   const [createTaskSubmitting, setCreateTaskSubmitting] = useState(false);
   const [createTaskError, setCreateTaskError] = useState<string | null>(null);
   const [createTaskForm, setCreateTaskForm] = useState<{
     title: string;
     content: string;
-    category: string;
     priority: 0 | 1 | 2 | 3;
     targetMinutes: number;
+    targetCycleCount: number;
+    cyclePeriod: 'daily' | 'weekly' | 'monthly' | 'custom';
+    customCycleDays: number;
+    event: string;
+    tagsText: string;
     startDate: string;
     dueDate: string;
   }>({
     title: '',
     content: '',
-    category: '',
     priority: 0,
     targetMinutes: 25,
+    targetCycleCount: 1,
+    cyclePeriod: 'daily',
+    customCycleDays: 1,
+    event: '',
+    tagsText: '',
     startDate: '',
     dueDate: '',
   });
@@ -82,19 +98,27 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   const [editTaskForm, setEditTaskForm] = useState<{
     title: string;
     content: string;
-    category: string;
-    status: 'todo' | 'doing' | 'done';
     priority: 0 | 1 | 2 | 3;
     targetMinutes: number;
+    currentCycleCount: number;
+    targetCycleCount: number;
+    cyclePeriod: 'daily' | 'weekly' | 'monthly' | 'custom';
+    customCycleDays: number;
+    event: string;
+    tagsText: string;
     startDate: string;
     dueDate: string;
   }>({
     title: '',
     content: '',
-    category: '',
-    status: 'todo',
     priority: 0,
     targetMinutes: 0,
+    currentCycleCount: 0,
+    targetCycleCount: 1,
+    cyclePeriod: 'daily',
+    customCycleDays: 1,
+    event: '',
+    tagsText: '',
     startDate: '',
     dueDate: '',
   });
@@ -134,6 +158,14 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     }
   }, [showTaskModal, activeTab]);
 
+  useEffect(() => {
+    if (!focusTargetTaskId) return;
+    const task = tasks.find((t) => t.id === focusTargetTaskId);
+    if (!task || task.status === 'done') {
+      setFocusTargetTaskId(null);
+    }
+  }, [tasks, focusTargetTaskId]);
+
 
   function _resetCreateTaskForm(): void {
     setCreateTaskSubmitting(false);
@@ -141,9 +173,13 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     setCreateTaskForm({
       title: '',
       content: '',
-      category: '',
       priority: 0,
       targetMinutes: 25,
+      targetCycleCount: 1,
+      cyclePeriod: 'daily',
+      customCycleDays: 1,
+      event: '',
+      tagsText: '',
       startDate: '',
       dueDate: '',
     });
@@ -210,10 +246,14 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     setEditTaskForm({
       title: task.title,
       content: task.content || '',
-      category: task.category,
-      status: task.status,
       priority: task.priority as 0 | 1 | 2 | 3,
       targetMinutes: Math.round(task.target_duration / 60),
+      currentCycleCount: task.current_cycle_count,
+      targetCycleCount: task.target_cycle_count,
+      cyclePeriod: task.cycle_period,
+      customCycleDays: task.cycle_every_days ?? 1,
+      event: task.event || '',
+      tagsText: task.tags.join(', '),
       startDate: task.start_date ? new Date(task.start_date).toISOString().slice(0, 16) : '',
       dueDate: task.due_date ? new Date(task.due_date).toISOString().slice(0, 16) : '',
     });
@@ -227,16 +267,25 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     try {
       const startDate = editTaskForm.startDate ? new Date(editTaskForm.startDate).toISOString() : null;
       const dueDate = editTaskForm.dueDate ? new Date(editTaskForm.dueDate).toISOString() : null;
+      const cycleEveryDays = editTaskForm.cyclePeriod === 'custom' ? Math.max(1, Math.floor(editTaskForm.customCycleDays || 1)) : null;
+      const tags = editTaskForm.tagsText
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean);
       await apiJson(`/todo/tasks/${selectedTask.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: editTaskForm.title.trim(),
           content: editTaskForm.content.trim() || null,
-          category: editTaskForm.category.trim(),
-          status: editTaskForm.status,
           priority: editTaskForm.priority,
           target_duration: Math.round(editTaskForm.targetMinutes * 60),
+          current_cycle_count: Math.max(0, Math.floor(editTaskForm.currentCycleCount || 0)),
+          target_cycle_count: Math.max(0, Math.floor(editTaskForm.targetCycleCount || 0)),
+          cycle_period: editTaskForm.cyclePeriod,
+          cycle_every_days: cycleEveryDays,
+          event: editTaskForm.event.trim(),
+          tags,
           start_date: startDate,
           due_date: dueDate,
         }),
@@ -308,8 +357,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex items-center gap-2 flex-1">
                     <div className={`w-2 h-2 rounded-full ${
-                      task.status === 'doing' ? 'bg-blue-500' :
-                      'bg-white/30'
+                      task.status === 'done' ? 'bg-green-500/50' : 'bg-white/30'
                     }`} />
                     <span className="font-medium text-white/90 line-clamp-1">
                       {task.title}
@@ -349,14 +397,8 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                   </div>
                 </div>
                 
-                {(task.content || task.category || task.due_date) && (
+                {(task.content || task.due_date) && (
                   <div className="flex items-center gap-4 text-xs text-white/40 pl-4">
-                    {task.category && (
-                      <span className="flex items-center gap-1">
-                        <span className="w-1 h-1 rounded-full bg-white/30" />
-                        {task.category}
-                      </span>
-                    )}
                     {task.due_date && (
                       <span className={new Date(task.due_date) < new Date() ? 'text-red-400' : ''}>
                         {new Date(task.due_date).toLocaleDateString()} 截止
@@ -368,7 +410,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
             ))
           ) : (
             <div className="text-center py-8 text-white/20 text-sm">
-              暂无进行中的任务
+              暂无待办任务
             </div>
           )}
         </div>
@@ -419,6 +461,10 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   function _pickTodayFocusTask(): Task | null {
     if (!tasks.length) return null;
     try {
+      if (focusTargetTaskId) {
+        const picked = tasks.find((t) => t.id === focusTargetTaskId && t.status !== 'done');
+        if (picked) return picked;
+      }
       const now = new Date();
       const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
       const tomorrowStart = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000);
@@ -492,6 +538,41 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     }
   }
 
+  function _switchFocusTarget(task: Task) {
+    if (task.status === 'done') return;
+    setFocusTargetTaskId(task.id);
+    setShowFocusTaskPicker(false);
+  }
+
+  async function _handleCompleteAndStopFocus(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (focusQuickActionBusy) return;
+    const targetTaskId = currentFocus?.task_id ?? _pickTodayFocusTask()?.id ?? null;
+    if (!targetTaskId) {
+      alert('没有可完成的即将专注任务');
+      return;
+    }
+    setFocusQuickActionBusy(true);
+    try {
+      await apiJson(`/todo/tasks/${targetTaskId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'done' }),
+      });
+      if (currentFocus?.task_id === targetTaskId) {
+        await apiJson('/todo/focus/stop', { method: 'POST' });
+        setCurrentFocus(null);
+      }
+      setFocusTargetTaskId((prev) => (prev === targetTaskId ? null : prev));
+      await Promise.all([_loadTasks(), _loadCurrentFocus(), _loadTodayFocus()]);
+    } catch (e) {
+      console.error('Failed to complete and stop focus', e);
+      alert('完成任务失败');
+    } finally {
+      setFocusQuickActionBusy(false);
+    }
+  }
+
   async function _submitCreateTask(): Promise<void> {
     if (createTaskSubmitting) return;
     const title = createTaskForm.title.trim();
@@ -510,16 +591,26 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     try {
       const startDate = createTaskForm.startDate ? new Date(createTaskForm.startDate).toISOString() : null;
       const dueDate = createTaskForm.dueDate ? new Date(createTaskForm.dueDate).toISOString() : null;
+      const cycleEveryDays = createTaskForm.cyclePeriod === 'custom' ? Math.max(1, Math.floor(createTaskForm.customCycleDays || 1)) : null;
+      const tags = createTaskForm.tagsText
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter(Boolean);
       await apiJson('/todo/tasks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title,
           content: createTaskForm.content.trim() ? createTaskForm.content : null,
-          category: createTaskForm.category.trim(),
           status: 'todo',
           priority: createTaskForm.priority,
           target_duration: Math.round(targetMinutes * 60),
+          current_cycle_count: 0,
+          target_cycle_count: Math.max(0, Math.floor(createTaskForm.targetCycleCount || 0)),
+          cycle_period: createTaskForm.cyclePeriod,
+          cycle_every_days: cycleEveryDays,
+          event: createTaskForm.event.trim(),
+          tags,
           start_date: startDate,
           due_date: dueDate,
         }),
@@ -532,6 +623,72 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     } finally {
       setCreateTaskSubmitting(false);
     }
+  }
+
+  function _renderCalendarView() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth();
+    const today = now.getDate();
+    const monthLabel = `${year}年${month + 1}月`;
+    const firstWeekday = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const daysInPrevMonth = new Date(year, month, 0).getDate();
+    const weekdays = ['日', '一', '二', '三', '四', '五', '六'];
+    const cells = Array.from({ length: 42 }, (_, i) => {
+      const offset = i - firstWeekday + 1;
+      if (offset < 1) {
+        return {
+          day: daysInPrevMonth + offset,
+          inCurrentMonth: false,
+          isToday: false,
+        };
+      }
+      if (offset > daysInMonth) {
+        return {
+          day: offset - daysInMonth,
+          inCurrentMonth: false,
+          isToday: false,
+        };
+      }
+      return {
+        day: offset,
+        inCurrentMonth: true,
+        isToday: offset === today,
+      };
+    });
+
+    return (
+      <div className="flex-1 bg-white/10 backdrop-blur-sm rounded-lg border border-white/20 p-3 flex flex-col">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-white/85 text-sm font-semibold">日历</span>
+          <span className="text-white/60 text-xs">{monthLabel}</span>
+        </div>
+        <div className="grid grid-cols-7 gap-1 text-[10px] text-white/45 mb-1">
+          {weekdays.map((day) => (
+            <div key={day} className="h-5 flex items-center justify-center">
+              {day}
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-1 flex-1">
+          {cells.map((cell, idx) => (
+            <div
+              key={`${cell.day}-${idx}`}
+              className={`h-6 rounded flex items-center justify-center text-[11px] ${
+                cell.isToday
+                  ? 'bg-blue-500/70 text-white font-semibold'
+                  : cell.inCurrentMonth
+                    ? 'text-white/80 bg-white/[0.03]'
+                    : 'text-white/25'
+              }`}
+            >
+              {cell.day}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   if (index === 0) {
@@ -557,8 +714,8 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                 className="absolute top-2 right-2 px-3 py-1.5 rounded-lg bg-black/20 hover:bg-black/40 text-white/40 hover:text-white/80 transition-all opacity-0 group-hover:opacity-100 z-10 w-12 flex items-center justify-center"
                 onClick={(e) => {
                   e.stopPropagation();
-                  // TODO: 切换专注模式
-                  console.log('Switch focus mode');
+                  setShowFocusTaskPicker(true);
+                  _loadTasks();
                 }}
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -566,6 +723,15 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                   <path d="M19 7H3"/>
                   <path d="M5 17l5 5 5-5"/>
                   <path d="M5 17h16"/>
+                </svg>
+              </button>
+              <button
+                className="absolute top-14 right-2 px-3 py-1.5 rounded-lg bg-black/20 hover:bg-black/40 text-white/40 hover:text-emerald-300 transition-all opacity-0 group-hover:opacity-100 z-10 w-12 flex items-center justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+                onClick={_handleCompleteAndStopFocus}
+                disabled={focusQuickActionBusy}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="20 6 9 17 4 12"></polyline>
                 </svg>
               </button>
 
@@ -613,6 +779,52 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
             </button>
           </div>
         </div>
+
+        {showFocusTaskPicker && (
+          <div
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+            onClick={() => setShowFocusTaskPicker(false)}
+          >
+            <div
+              className="w-[560px] max-w-[92vw] max-h-[72vh] bg-[#1a1a1a] border border-white/10 rounded-2xl shadow-2xl overflow-hidden"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="h-14 border-b border-white/10 flex items-center justify-between px-5 bg-white/5">
+                <h3 className="text-lg font-bold text-white">全部任务</h3>
+                <button
+                  onClick={() => setShowFocusTaskPicker(false)}
+                  className="p-2 hover:bg-white/10 rounded-full transition-colors text-white/60 hover:text-white"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                  </svg>
+                </button>
+              </div>
+              <div className="p-4 overflow-y-auto max-h-[calc(72vh-56px)] flex flex-col gap-2">
+                {tasks.filter((task) => task.status !== 'done').map((task) => (
+                  <button
+                    key={task.id}
+                    onClick={() => _switchFocusTarget(task)}
+                    className={`w-full text-left px-3 py-2 rounded-lg border transition-colors ${
+                      focusTargetTaskId === task.id
+                          ? 'border-blue-500/40 bg-blue-500/10 text-white'
+                          : 'border-white/10 bg-white/5 text-white/85 hover:bg-white/10'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span>{task.title}</span>
+                      <span className="text-xs text-white/45">待办</span>
+                    </div>
+                  </button>
+                ))}
+                {tasks.filter((task) => task.status !== 'done').length === 0 && (
+                  <div className="text-center text-white/35 py-6">暂无任务</div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* 专注时长统计悬浮页面 */}
         {showStatsModal && (
@@ -678,29 +890,18 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                   />
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex flex-col gap-2">
-                    <label className="text-sm text-white/70">分类</label>
-                    <input
-                      value={editTaskForm.category}
-                      onChange={(e) => setEditTaskForm((s) => ({ ...s, category: e.target.value }))}
-                      placeholder="例如：工作/学习"
-                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <label className="text-sm text-white/70">优先级</label>
-                    <select
-                      value={editTaskForm.priority}
-                      onChange={(e) => setEditTaskForm((s) => ({ ...s, priority: Number(e.target.value) as 0 | 1 | 2 | 3 }))}
-                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-                    >
-                      <option value={0}>0 低</option>
-                      <option value={1}>1</option>
-                      <option value={2}>2</option>
-                      <option value={3}>3 高</option>
-                    </select>
-                  </div>
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm text-white/70">优先级</label>
+                  <select
+                    value={editTaskForm.priority}
+                    onChange={(e) => setEditTaskForm((s) => ({ ...s, priority: Number(e.target.value) as 0 | 1 | 2 | 3 }))}
+                    className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                  >
+                    <option value={0}>0 低</option>
+                    <option value={1}>1</option>
+                    <option value={2}>2</option>
+                    <option value={3}>3 高</option>
+                  </select>
                 </div>
 
                 <div className="flex flex-col gap-2">
@@ -725,18 +926,55 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                     />
                   </div>
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm text-white/70">状态</label>
+                    <label className="text-sm text-white/70">循环周期</label>
                     <select
-                      value={editTaskForm.status}
-                      onChange={(e) => setEditTaskForm((s) => ({ ...s, status: e.target.value as 'todo' | 'doing' | 'done' }))}
+                      value={editTaskForm.cyclePeriod}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, cyclePeriod: e.target.value as 'daily' | 'weekly' | 'monthly' | 'custom' }))}
                       className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                     >
-                      <option value="todo">待办</option>
-                      <option value="doing">进行中</option>
-                      <option value="done">已完成</option>
+                      <option value="daily">每日</option>
+                      <option value="weekly">每周</option>
+                      <option value="monthly">每月</option>
+                      <option value="custom">自定义</option>
                     </select>
                   </div>
                 </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">当前循环次数</label>
+                    <input
+                      type="number"
+                      min={0}
+                      value={editTaskForm.currentCycleCount}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, currentCycleCount: Number(e.target.value) }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">目的循环次数</label>
+                    <input
+                      type="number"
+                      min={0}
+                      value={editTaskForm.targetCycleCount}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, targetCycleCount: Number(e.target.value) }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                </div>
+
+                {editTaskForm.cyclePeriod === 'custom' && (
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">自定义间隔（天）</label>
+                    <input
+                      type="number"
+                      min={1}
+                      value={editTaskForm.customCycleDays}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, customCycleDays: Number(e.target.value) }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                )}
 
                 <div className="grid grid-cols-2 gap-3">
                   <div className="flex flex-col gap-2">
@@ -755,6 +993,27 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                       value={editTaskForm.dueDate}
                       onChange={(e) => setEditTaskForm((s) => ({ ...s, dueDate: e.target.value }))}
                       className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">事件</label>
+                    <input
+                      value={editTaskForm.event}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, event: e.target.value }))}
+                      placeholder="例如：晨间阅读"
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">标签</label>
+                    <input
+                      value={editTaskForm.tagsText}
+                      onChange={(e) => setEditTaskForm((s) => ({ ...s, tagsText: e.target.value }))}
+                      placeholder="逗号分隔，例如：学习,arxiv"
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                     />
                   </div>
                 </div>
@@ -904,15 +1163,6 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
 
                 <div className="grid grid-cols-2 gap-3">
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm text-white/70">分类</label>
-                    <input
-                      value={createTaskForm.category}
-                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, category: e.target.value }))}
-                      placeholder="例如：工作/学习"
-                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2">
                     <label className="text-sm text-white/70">优先级</label>
                     <select
                       value={createTaskForm.priority}
@@ -949,14 +1199,43 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                     />
                   </div>
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm text-white/70">状态</label>
-                    <input
-                      value="todo"
-                      disabled
-                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white/60"
-                    />
+                    <label className="text-sm text-white/70">循环周期</label>
+                    <select
+                      value={createTaskForm.cyclePeriod}
+                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, cyclePeriod: e.target.value as 'daily' | 'weekly' | 'monthly' | 'custom' }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    >
+                      <option value="daily">每日</option>
+                      <option value="weekly">每周</option>
+                      <option value="monthly">每月</option>
+                      <option value="custom">自定义</option>
+                    </select>
                   </div>
                 </div>
+
+                <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">目的循环次数</label>
+                    <input
+                      type="number"
+                      min={0}
+                      value={createTaskForm.targetCycleCount}
+                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, targetCycleCount: Number(e.target.value) }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                </div>
+
+                {createTaskForm.cyclePeriod === 'custom' && (
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">自定义间隔（天）</label>
+                    <input
+                      type="number"
+                      min={1}
+                      value={createTaskForm.customCycleDays}
+                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, customCycleDays: Number(e.target.value) }))}
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                )}
 
                 <div className="grid grid-cols-2 gap-3">
                   <div className="flex flex-col gap-2">
@@ -975,6 +1254,27 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
                       value={createTaskForm.dueDate}
                       onChange={(e) => setCreateTaskForm((s) => ({ ...s, dueDate: e.target.value }))}
                       className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">事件</label>
+                    <input
+                      value={createTaskForm.event}
+                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, event: e.target.value }))}
+                      placeholder="例如：晨间阅读"
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-white/70">标签</label>
+                    <input
+                      value={createTaskForm.tagsText}
+                      onChange={(e) => setCreateTaskForm((s) => ({ ...s, tagsText: e.target.value }))}
+                      placeholder="逗号分隔，例如：学习,arxiv"
+                      className="w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
                     />
                   </div>
                 </div>
@@ -1012,21 +1312,25 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     return (
       <div className="flex-1 flex gap-2">
         {Array.from({ length: split }).map((_, subIndex) => (
-          <div
-            key={subIndex}
-            onClick={index === 3 && subIndex === 2 ? () => navigate('/apps') : undefined}
-            className={`flex-1 bg-white/10 backdrop-blur-sm rounded-lg border border-white/20 flex items-center justify-center text-white/50 hover:bg-white/20 transition-colors ${
-              index === 3 && subIndex === 2 ? 'cursor-pointer' : ''
-            }`}
-          >
-            {index === 3 && subIndex === 2 ? (
-              <span className="text-white/80 font-medium">应用中心</span>
-            ) : index === 3 && subIndex === 0 ? (
-              <span className="text-white/80 font-medium">成就</span>
-            ) : (
-              <span>Placeholder {index + 1}-{subIndex + 1}</span>
-            )}
-          </div>
+          index === 1 && subIndex === 0 ? (
+            <React.Fragment key={subIndex}>{_renderCalendarView()}</React.Fragment>
+          ) : (
+            <div
+              key={subIndex}
+              onClick={index === 3 && subIndex === 2 ? () => navigate('/apps') : undefined}
+              className={`flex-1 bg-white/10 backdrop-blur-sm rounded-lg border border-white/20 flex items-center justify-center text-white/50 hover:bg-white/20 transition-colors ${
+                index === 3 && subIndex === 2 ? 'cursor-pointer' : ''
+              }`}
+            >
+              {index === 3 && subIndex === 2 ? (
+                <span className="text-white/80 font-medium">应用中心</span>
+              ) : index === 3 && subIndex === 0 ? (
+                <span className="text-white/80 font-medium">成就</span>
+              ) : (
+                <span>Placeholder {index + 1}-{subIndex + 1}</span>
+              )}
+            </div>
+          )
         ))}
       </div>
     );


### PR DESCRIPTION
## 背景
本次改动用于简化任务模型并完善右侧卡片的快捷操作：
- 创建任务页面不再维护“分类”和“当前循环次数”输入。
- 后端任务定义与 tasks 表去除 category 字段，避免前后端定义不一致。
- 对勾按钮支持在“当前没有专注”时，直接完成“即将专注”的任务。

## 主要变更
- 前端：调整任务创建/编辑表单，移除分类相关展示与提交字段。
- 前端：更新对勾按钮逻辑，优先完成目标任务；若目标正处于专注中则同时停止专注。
- 后端：Task 请求/响应模型移除 category；任务查询、创建、更新 SQL 同步移除该列。
- 后端：初始化流程增加 ALTER TABLE tasks DROP COLUMN IF EXISTS category。
- 后端：arxiv 生成任务写入语句移除 category。

## 验证
- 前端：pnpm lint 与 pnpm build 通过（存在既有 warning，不影响构建）。
- 后端：uv run ruff check 与 uv run pytest 通过（21 passed）。

## 风险与影响
- 数据库层面对 category 执行删除后不可逆，历史分类数据将被移除。
- 其余改动为兼容性收敛，风险较低。