### PR TITLE
feat(frontend): ChatBox 引入 Markdown 与富文本渲染

### DIFF
--- a/.agents/workflows/git-flow.md
+++ b/.agents/workflows/git-flow.md
@@ -1,0 +1,112 @@
+---
+description: Guides GitHub Flow from branch creation to PR merge. Invoke when user asks to implement features/fixes with proper branching, commits, PR, and review workflow.
+---
+
+# GitHub Flow
+
+Use this skill to execute a standard GitHub Flow process for feature or bugfix delivery.
+
+## When to Invoke
+
+- User asks to implement a feature and submit via pull request
+- User asks to fix a bug following branch + PR workflow
+- User asks for a safe release path without long-lived release branches
+- User asks how to work collaboratively with review gates
+
+## Core Principles
+
+- Keep `main` always deployable
+- Use short-lived branches from latest `main`
+- Make small, reviewable commits
+- Open pull request early and update continuously
+- Merge only after checks pass and review is approved
+
+## Standard Workflow
+
+1. Sync local `main` with remote
+2. Create a branch using clear naming:
+   - `feature/<short-description>`
+   - `fix/<short-description>`
+   - `chore/<short-description>`
+3. Implement in small increments
+4. Commit with clear intent (Conventional Commits preferred)
+5. Push branch and open PR against `main`
+6. Ensure CI passes and address review feedback
+7. Squash or rebase-merge according to repo policy
+8. Delete merged branch
+
+## Branch Naming Convention
+
+- Lowercase words joined by hyphens
+- Include scope when useful
+- Examples:
+  - `feature/arxiv-search-filters`
+  - `fix/login-timeout-retry`
+  - `chore/update-lint-rules`
+
+## Commit Convention
+
+Prefer Conventional Commits:
+
+- `feat: add arxiv scope switch`
+- `fix: handle empty response in paper list`
+- `chore: align eslint config`
+- `refactor: simplify focus state sync`
+- `test: add api chat error coverage`
+
+## Pull Request Checklist
+
+- PR title clearly describes change
+- Description includes context, change summary, and risk
+- Linked issue/task if available
+- Tests added/updated for behavior changes
+- CI checks are green
+- Review comments resolved
+
+## Review and Merge Policy
+
+- At least one meaningful approval
+- No unresolved conversations
+- No failing required checks
+- Merge strategy follows repository rules
+
+## Safety Guardrails
+
+- Do not force-push shared branches unless coordinated
+- Do not merge with failing required status checks
+- Do not bypass review policy for non-emergency changes
+- Keep PR focused; split large changes when needed
+
+## Output Template
+
+When asked to run GitHub Flow, structure output as:
+
+1. Branch plan
+2. Change summary
+3. Commit plan or commit list
+4. PR draft (title + description)
+5. Validation status (tests/CI)
+6. Merge readiness decision
+
+## Example PR Title
+
+- `feat(arxiv): add search scope selector`
+- `fix(todo): correct focus switch behavior`
+
+## Example PR Description Template
+
+```md
+## Why
+<problem statement>
+
+## What
+- <change 1>
+- <change 2>
+
+## Validation
+- <tests run>
+- <results>
+
+## Risks
+- <known risk or "low">
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.3.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.0.2",
     "zustand": "^5.0.3"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-router-dom:
         specifier: ^7.3.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.5.0
@@ -885,6 +888,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
     engines: {node: '>=18'}
@@ -1291,8 +1298,32 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1320,6 +1351,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1500,11 +1552,17 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -2591,6 +2649,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-plugin-react-hooks@7.0.1(eslint@10.0.3(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
@@ -2963,6 +3023,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -2977,6 +3046,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3071,6 +3197,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -3308,6 +3492,17 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3324,6 +3519,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { apiFetch, apiJson, apiSSE } from '../lib/api';
+import MarkdownContent from './MarkdownContent';
 
 /**
  * 聊天框组件
@@ -261,7 +262,11 @@ const ChatBox: React.FC<ChatBoxProps> = ({
               m.role === 'user' ? 'ml-auto bg-white/10' : 'bg-white/5',
             ].join(' ')}
           >
-            {m.content}
+            {m.role === 'assistant' ? (
+              <MarkdownContent content={m.content} />
+            ) : (
+              m.content
+            )}
           </div>
         ))}
 

--- a/frontend/src/components/MarkdownContent.tsx
+++ b/frontend/src/components/MarkdownContent.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Components } from 'react-markdown';
+
+type MarkdownContentProps = {
+  content: string;
+  className?: string;
+};
+
+const components: Components = {
+  code({ className, children, ...props }) {
+    const match = /language-(\w+)/.exec(className || '');
+    const isBlock = match || (typeof children === 'string' && children.includes('\n'));
+    if (isBlock) {
+      return (
+        <pre className="md-code-block">
+          <code className={className} {...props}>
+            {children}
+          </code>
+        </pre>
+      );
+    }
+    return (
+      <code className="md-inline-code" {...props}>
+        {children}
+      </code>
+    );
+  },
+
+  a({ children, ...props }) {
+    return (
+      <a target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+    );
+  },
+
+  table({ children, ...props }) {
+    return (
+      <div className="md-table-wrapper">
+        <table {...props}>{children}</table>
+      </div>
+    );
+  },
+};
+
+const MarkdownContent: React.FC<MarkdownContentProps> = ({ content, className }) => {
+  return (
+    <div className={['markdown-body', className || ''].join(' ').trim()}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownContent;

--- a/frontend/src/components/__tests__/MarkdownContent.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownContent.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom';
+
+import MarkdownContent from '../MarkdownContent';
+
+describe('MarkdownContent', () => {
+  it('renders bold text as <strong>', () => {
+    render(<MarkdownContent content="这是 **加粗** 文字" />);
+    const strong = screen.getByText('加粗');
+    expect(strong.tagName).toBe('STRONG');
+  });
+
+  it('renders inline code with md-inline-code class', () => {
+    render(<MarkdownContent content="使用 `console.log` 调试" />);
+    const code = screen.getByText('console.log');
+    expect(code).toHaveClass('md-inline-code');
+    expect(code.tagName).toBe('CODE');
+  });
+
+  it('renders code blocks inside md-code-block container', () => {
+    const md = '```js\nconst x = 1;\n```';
+    render(<MarkdownContent content={md} />);
+    const codeBlock = document.querySelector('.md-code-block');
+    expect(codeBlock).toBeInTheDocument();
+    expect(codeBlock?.tagName).toBe('PRE');
+    expect(screen.getByText('const x = 1;')).toBeInTheDocument();
+  });
+
+  it('renders GFM tables with md-table-wrapper', () => {
+    const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+    render(<MarkdownContent content={md} />);
+    const wrapper = document.querySelector('.md-table-wrapper');
+    expect(wrapper).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders links with target="_blank"', () => {
+    render(<MarkdownContent content="[Google](https://google.com)" />);
+    const link = screen.getByText('Google');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders unordered lists', () => {
+    const md = '- item A\n- item B\n- item C';
+    render(<MarkdownContent content={md} />);
+    expect(screen.getByText('item A')).toBeInTheDocument();
+    expect(screen.getByText('item B')).toBeInTheDocument();
+    const listItems = document.querySelectorAll('li');
+    expect(listItems.length).toBe(3);
+  });
+
+  it('applies markdown-body class to wrapper', () => {
+    const { container } = render(<MarkdownContent content="hello" />);
+    expect(container.firstChild).toHaveClass('markdown-body');
+  });
+
+  it('appends custom className to wrapper', () => {
+    const { container } = render(<MarkdownContent content="hello" className="extra" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass('markdown-body');
+    expect(wrapper).toHaveClass('extra');
+  });
+
+  it('renders GFM strikethrough', () => {
+    render(<MarkdownContent content="~~deleted~~" />);
+    const del = document.querySelector('del');
+    expect(del).toBeInTheDocument();
+    expect(del?.textContent).toBe('deleted');
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,3 +24,148 @@
   transform-origin: 50% 50%;
   animation: tag-edit-wiggle 0.18s ease-in-out infinite alternate;
 }
+
+/* ── Markdown content styling for ChatBox assistant messages ── */
+
+.markdown-body {
+  font-size: 0.875rem;
+  line-height: 1.625;
+  word-break: break-word;
+}
+
+.markdown-body > *:first-child {
+  margin-top: 0;
+}
+
+.markdown-body > *:last-child {
+  margin-bottom: 0;
+}
+
+/* Headings */
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  font-weight: 600;
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+.markdown-body h1 { font-size: 1.25rem; }
+.markdown-body h2 { font-size: 1.125rem; }
+.markdown-body h3 { font-size: 1rem; }
+
+/* Paragraphs */
+.markdown-body p {
+  margin: 0.5em 0;
+}
+
+/* Inline code */
+.markdown-body .md-inline-code {
+  background: rgba(255, 255, 255, 0.12);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.85em;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+}
+
+/* Code blocks */
+.markdown-body .md-code-block {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 8px;
+  padding: 0.75em 1em;
+  overflow-x: auto;
+  margin: 0.5em 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+}
+
+.markdown-body .md-code-block code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* Tables */
+.markdown-body .md-table-wrapper {
+  overflow-x: auto;
+  margin: 0.5em 0;
+}
+
+.markdown-body table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.8125rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.4em 0.75em;
+  text-align: left;
+}
+
+.markdown-body th {
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.markdown-body tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* Lists */
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 1.5em;
+  margin: 0.4em 0;
+}
+
+.markdown-body li {
+  margin: 0.15em 0;
+}
+
+.markdown-body li > p {
+  margin: 0.25em 0;
+}
+
+/* Blockquotes */
+.markdown-body blockquote {
+  border-left: 3px solid rgba(255, 255, 255, 0.25);
+  padding-left: 0.75em;
+  margin: 0.5em 0;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+/* Links */
+.markdown-body a {
+  color: #93c5fd;
+  text-decoration: underline;
+  text-decoration-color: rgba(147, 197, 253, 0.3);
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.15s;
+}
+
+.markdown-body a:hover {
+  text-decoration-color: rgba(147, 197, 253, 0.8);
+}
+
+/* Horizontal rule */
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin: 0.75em 0;
+}
+
+/* Strong & emphasis */
+.markdown-body strong {
+  font-weight: 600;
+}
+
+/* Strikethrough (GFM) */
+.markdown-body del {
+  text-decoration: line-through;
+  opacity: 0.7;
+}


### PR DESCRIPTION
## Why
`ChatBox.tsx` 中的消息渲染采用纯文本方式 (`{m.content}`)。LLM 常输出含粗体、代码块、列表、表格的 Markdown 内容，纯文本展示破坏阅读体验。

Closes #42

## What
- 新增 `MarkdownContent` 组件，封装 `react-markdown` + `remark-gfm`
- 自定义渲染器：代码块（深色背景容器）、链接（新窗口打开）、表格（响应式溢出）
- 在 `ChatBox.tsx` 中仅对 **assistant 消息** 使用 Markdown 渲染，user 消息保持纯文本
- 在 `index.css` 添加 `.markdown-body` 作用域下的排版样式（标题、代码、表格、列表、引用、链接等）
- 新增 `remark-gfm` 依赖 (v4.0.1)

## Validation
- `pnpm check` — TypeScript 编译通过
- `pnpm lint` — 0 errors (2 pre-existing warnings)
- `pnpm test --run` — 18/18 tests passing (含 9 个新增 MarkdownContent 测试)
- 浏览器验证：代码块、列表等 Markdown 内容正确渲染

## Risks
- Low — 仅影响 assistant 消息的渲染方式，user 消息不变