### PR TITLE
refactor(backend): 将 assistant_runner.py 的原始 SQL 抽离为 Service 层

### DIFF
--- a/backend/MCP/assistant_runner.py
+++ b/backend/MCP/assistant_runner.py
@@ -18,13 +18,20 @@ import json
 import os
 import re
 from collections.abc import AsyncGenerator
-from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 from fastapi import Request
 
 from routes.auth_routes import _user_from_token as _auth_user_from_token
+from services.arxiv_service import get_daily_candidates, get_daily_candidates_for_tasks
+from services.todo_service import (
+    get_events_list,
+    get_focus_current,
+    get_focus_today,
+    get_primary_event,
+    get_today_tasks,
+)
 
 from .mcp_registry import MCPRegistry
 from .mcp_stdio import MCPProtocolError
@@ -215,6 +222,8 @@ def _bearer_token_from_request(request: Request) -> str | None:
     return None
 
 
+
+
 async def _builtin_todo_list_today(request: Request) -> str:
     """内置工具：查询当前登录用户的“今日任务”。
     说明：
@@ -231,50 +240,9 @@ async def _builtin_todo_list_today(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            WITH bounds AS (
-              SELECT date_trunc('day', NOW()) AS day_start,
-                     date_trunc('day', NOW()) + interval '1 day' AS day_end
-            )
-            SELECT id, title, status, priority, start_date, due_date
-            FROM tasks t
-            CROSS JOIN bounds b
-            WHERE t.user_id = $1
-              AND t.is_deleted = FALSE
-              AND (
-                (t.start_date IS NOT NULL AND t.start_date >= b.day_start AND t.start_date < b.day_end)
-                OR
-                (t.due_date IS NOT NULL AND t.due_date >= b.day_start AND t.due_date < b.day_end)
-              )
-            ORDER BY priority DESC, updated_at DESC
-            LIMIT 100
-            """,
-            int(user.id),
-        )
-    data = [
-        {
-            "id": str(r["id"]),
-            "title": str(r["title"]),
-            "status": str(r["status"]),
-            "priority": int(r["priority"]),
-            "start_date": r["start_date"].isoformat() if r["start_date"] else None,
-            "due_date": r["due_date"].isoformat() if r["due_date"] else None,
-        }
-        for r in rows
-    ]
+
+    data = await get_today_tasks(pool, int(user.id))
     return json.dumps({"today_tasks": data}, ensure_ascii=False)
-
-
-def _event_row_to_payload(row: Any) -> dict[str, Any]:
-    return {
-        "id": str(row["id"]),
-        "name": str(row["name"]),
-        "due_at": row["due_at"].isoformat() if row["due_at"] else None,
-        "created_at": row["created_at"].isoformat() if row["created_at"] else None,
-        "is_primary": bool(row["is_primary"]),
-    }
 
 
 async def _builtin_event_primary(request: Request) -> str:
@@ -287,17 +255,9 @@ async def _builtin_event_primary(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT id, name, due_at, created_at, is_primary
-            FROM events
-            WHERE user_id = $1 AND is_primary = TRUE
-            LIMIT 1
-            """,
-            int(user.id),
-        )
-    return json.dumps({"primary_event": _event_row_to_payload(row) if row else None}, ensure_ascii=False)
+
+    event = await get_primary_event(pool, int(user.id))
+    return json.dumps({"primary_event": event}, ensure_ascii=False)
 
 
 async def _builtin_events_list(request: Request) -> str:
@@ -310,18 +270,9 @@ async def _builtin_events_list(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id, name, due_at, created_at, is_primary
-            FROM events
-            WHERE user_id = $1
-            ORDER BY due_at ASC, created_at DESC
-            LIMIT 100
-            """,
-            int(user.id),
-        )
-    return json.dumps({"events": [_event_row_to_payload(row) for row in rows]}, ensure_ascii=False)
+
+    events = await get_events_list(pool, int(user.id))
+    return json.dumps({"events": events}, ensure_ascii=False)
 
 
 async def _builtin_focus_current(request: Request) -> str:
@@ -334,47 +285,8 @@ async def _builtin_focus_current(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT id, user_id, task_id, duration, start_time, end_at, created_at
-            FROM focus_logs
-            WHERE user_id = $1 AND end_at IS NULL
-            """,
-            int(user.id),
-        )
-        if row is None:
-            return json.dumps({"is_focusing": False}, ensure_ascii=False)
-        from datetime import datetime
 
-        dur = int((datetime.now(UTC) - row["start_time"]).total_seconds())
-        if dur < 0:
-            dur = 0
-        task_row = await conn.fetchrow(
-            """
-            SELECT id, title, status
-            FROM tasks
-            WHERE id = $1 AND user_id = $2 AND is_deleted = FALSE
-            """,
-            row["task_id"],
-            int(user.id),
-        )
-    payload = {
-        "is_focusing": True,
-        "task": (
-            {
-                "id": str(task_row["id"]),
-                "title": str(task_row["title"]),
-                "status": str(task_row["status"]),
-            }
-            if task_row
-            else {"id": str(row["task_id"])}
-        ),
-        "focus": {
-            "start_time": row["start_time"].isoformat(),
-            "duration_seconds": dur,
-        },
-    }
+    payload = await get_focus_current(pool, int(user.id))
     return json.dumps(payload, ensure_ascii=False)
 
 
@@ -388,40 +300,9 @@ async def _builtin_focus_today(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            WITH bounds AS (
-              SELECT date_trunc('day', NOW()) AS day_start,
-                     date_trunc('day', NOW()) + interval '1 day' AS day_end
-            )
-            SELECT
-              COALESCE(
-                SUM(
-                  GREATEST(
-                    0,
-                    EXTRACT(
-                      epoch FROM (
-                        LEAST(COALESCE(fl.end_at, NOW()), b.day_end)
-                        - GREATEST(fl.start_time, b.day_start)
-                      )
-                    )
-                  )
-                ),
-                0
-              )::BIGINT AS seconds
-            FROM focus_logs fl
-            CROSS JOIN bounds b
-            WHERE fl.user_id = $1
-              AND fl.start_time < b.day_end
-              AND COALESCE(fl.end_at, NOW()) > b.day_start
-            """,
-            int(user.id),
-        )
-    seconds = int((row or {}).get("seconds") or 0)
-    if seconds < 0:
-        seconds = 0
-    return json.dumps({"seconds": seconds, "minutes": seconds // 60}, ensure_ascii=False)
+
+    payload = await get_focus_today(pool, int(user.id))
+    return json.dumps(payload, ensure_ascii=False)
 
 
 async def _builtin_focus_start(request: Request, args: dict[str, Any]) -> str:
@@ -491,27 +372,8 @@ async def _builtin_arxiv_daily_candidates(request: Request) -> str:
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    today = datetime.now(UTC).date()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT arxiv_id, title, summary
-            FROM arxiv_daily_candidates
-            WHERE user_id = $1 AND candidate_date = $2
-            ORDER BY created_at DESC
-            LIMIT 50
-            """,
-            int(user.id),
-            today,
-        )
-    papers = [
-        {
-            "arxiv_id": str(r["arxiv_id"]),
-            "title": str(r["title"]),
-            "summary": str(r["summary"]),
-        }
-        for r in rows
-    ]
+
+    papers = await get_daily_candidates(pool, int(user.id))
     return json.dumps({"daily_candidates": papers}, ensure_ascii=False)
 
 
@@ -525,38 +387,14 @@ async def _builtin_arxiv_daily_prepare_add_tasks(request: Request, args: dict[st
     user = await _auth_user_from_token(pool, token)
     if user is None:
         return "登录已失效或无效"
-    today = datetime.now(UTC).date()
+
     ids_arg = args.get("arxiv_ids")
     requested = [str(x).strip() for x in ids_arg] if isinstance(ids_arg, list) else []
-    async with pool.acquire() as conn:
-        if requested:
-            rows = await conn.fetch(
-                """
-                SELECT arxiv_id, title, summary
-                FROM arxiv_daily_candidates
-                WHERE user_id = $1 AND candidate_date = $2 AND arxiv_id = ANY($3::text[])
-                ORDER BY created_at DESC
-                LIMIT 50
-                """,
-                int(user.id),
-                today,
-                requested,
-            )
-        else:
-            rows = await conn.fetch(
-                """
-                SELECT arxiv_id, title, summary
-                FROM arxiv_daily_candidates
-                WHERE user_id = $1 AND candidate_date = $2
-                ORDER BY created_at DESC
-                LIMIT 10
-                """,
-                int(user.id),
-                today,
-            )
-    selected_ids = [str(r["arxiv_id"]) for r in rows]
+
+    selected_ids = await get_daily_candidates_for_tasks(pool, int(user.id), requested)
     if not selected_ids:
         return "今日暂无可添加到任务的论文候选"
+
     return json.dumps(
         {
             "action": "confirm",

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for database operations."""

--- a/backend/services/arxiv_service.py
+++ b/backend/services/arxiv_service.py
@@ -1,0 +1,57 @@
+from datetime import UTC, datetime
+from typing import Any
+
+
+async def get_daily_candidates(pool: Any, user_id: int) -> list[dict[str, Any]]:
+    today = datetime.now(UTC).date()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT arxiv_id, title, summary
+            FROM arxiv_daily_candidates
+            WHERE user_id = $1 AND candidate_date = $2
+            ORDER BY created_at DESC
+            LIMIT 50
+            """,
+            int(user_id),
+            today,
+        )
+    return [
+        {
+            "arxiv_id": str(r["arxiv_id"]),
+            "title": str(r["title"]),
+            "summary": str(r["summary"]),
+        }
+        for r in rows
+    ]
+
+
+async def get_daily_candidates_for_tasks(pool: Any, user_id: int, arxiv_ids: list[str]) -> list[str]:
+    today = datetime.now(UTC).date()
+    async with pool.acquire() as conn:
+        if arxiv_ids:
+            rows = await conn.fetch(
+                """
+                SELECT arxiv_id, title, summary
+                FROM arxiv_daily_candidates
+                WHERE user_id = $1 AND candidate_date = $2 AND arxiv_id = ANY($3::text[])
+                ORDER BY created_at DESC
+                LIMIT 50
+                """,
+                int(user_id),
+                today,
+                arxiv_ids,
+            )
+        else:
+            rows = await conn.fetch(
+                """
+                SELECT arxiv_id, title, summary
+                FROM arxiv_daily_candidates
+                WHERE user_id = $1 AND candidate_date = $2
+                ORDER BY created_at DESC
+                LIMIT 10
+                """,
+                int(user_id),
+                today,
+            )
+    return [str(r["arxiv_id"]) for r in rows]

--- a/backend/services/todo_service.py
+++ b/backend/services/todo_service.py
@@ -1,0 +1,157 @@
+from datetime import UTC, datetime
+from typing import Any
+
+
+async def get_today_tasks(pool: Any, user_id: int) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            WITH bounds AS (
+              SELECT date_trunc('day', NOW()) AS day_start,
+                     date_trunc('day', NOW()) + interval '1 day' AS day_end
+            )
+            SELECT id, title, status, priority, start_date, due_date
+            FROM tasks t
+            CROSS JOIN bounds b
+            WHERE t.user_id = $1
+              AND t.is_deleted = FALSE
+              AND (
+                (t.start_date IS NOT NULL AND t.start_date >= b.day_start AND t.start_date < b.day_end)
+                OR
+                (t.due_date IS NOT NULL AND t.due_date >= b.day_start AND t.due_date < b.day_end)
+              )
+            ORDER BY priority DESC, updated_at DESC
+            LIMIT 100
+            """,
+            int(user_id),
+        )
+    return [
+        {
+            "id": str(r["id"]),
+            "title": str(r["title"]),
+            "status": str(r["status"]),
+            "priority": int(r["priority"]),
+            "start_date": r["start_date"].isoformat() if r["start_date"] else None,
+            "due_date": r["due_date"].isoformat() if r["due_date"] else None,
+        }
+        for r in rows
+    ]
+
+
+def _event_row_to_payload(row: Any) -> dict[str, Any]:
+    return {
+        "id": str(row["id"]),
+        "name": str(row["name"]),
+        "due_at": row["due_at"].isoformat() if row["due_at"] else None,
+        "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+        "is_primary": bool(row["is_primary"]),
+    }
+
+
+async def get_primary_event(pool: Any, user_id: int) -> dict[str, Any] | None:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name, due_at, created_at, is_primary
+            FROM events
+            WHERE user_id = $1 AND is_primary = TRUE
+            LIMIT 1
+            """,
+            int(user_id),
+        )
+    return _event_row_to_payload(row) if row else None
+
+
+async def get_events_list(pool: Any, user_id: int) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, name, due_at, created_at, is_primary
+            FROM events
+            WHERE user_id = $1
+            ORDER BY due_at ASC, created_at DESC
+            LIMIT 100
+            """,
+            int(user_id),
+        )
+    return [_event_row_to_payload(row) for row in rows]
+
+
+async def get_focus_current(pool: Any, user_id: int) -> dict[str, Any]:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, user_id, task_id, duration, start_time, end_at, created_at
+            FROM focus_logs
+            WHERE user_id = $1 AND end_at IS NULL
+            """,
+            int(user_id),
+        )
+        if row is None:
+            return {"is_focusing": False}
+
+        dur = int((datetime.now(UTC) - row["start_time"]).total_seconds())
+        if dur < 0:
+            dur = 0
+        task_row = await conn.fetchrow(
+            """
+            SELECT id, title, status
+            FROM tasks
+            WHERE id = $1 AND user_id = $2 AND is_deleted = FALSE
+            """,
+            row["task_id"],
+            int(user_id),
+        )
+    return {
+        "is_focusing": True,
+        "task": (
+            {
+                "id": str(task_row["id"]),
+                "title": str(task_row["title"]),
+                "status": str(task_row["status"]),
+            }
+            if task_row
+            else {"id": str(row["task_id"])}
+        ),
+        "focus": {
+            "start_time": row["start_time"].isoformat(),
+            "duration_seconds": dur,
+        },
+    }
+
+
+async def get_focus_today(pool: Any, user_id: int) -> dict[str, int]:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            WITH bounds AS (
+              SELECT date_trunc('day', NOW()) AS day_start,
+                     date_trunc('day', NOW()) + interval '1 day' AS day_end
+            )
+            SELECT
+              COALESCE(
+                SUM(
+                  GREATEST(
+                    0,
+                    EXTRACT(
+                      epoch FROM (
+                        LEAST(COALESCE(fl.end_at, NOW()), b.day_end)
+                        - GREATEST(fl.start_time, b.day_start)
+                      )
+                    )
+                  )
+                ),
+                0
+              )::BIGINT AS seconds
+            FROM focus_logs fl
+            CROSS JOIN bounds b
+            WHERE fl.user_id = $1
+              AND fl.start_time < b.day_end
+              AND COALESCE(fl.end_at, NOW()) > b.day_start
+            """,
+            int(user_id),
+        )
+    seconds = int((row or {}).get("seconds") or 0)
+    if seconds < 0:
+        seconds = 0
+    return {"seconds": seconds, "minutes": seconds // 60}


### PR DESCRIPTION
解决 #43

## 背景 (Why)
`assistant_runner.py` 目前硬编码了大量 SQL 逻辑，将集成层（MCP 工具集成）与持久层（数据库访问）混杂在一起。这打破了系统层级的边界隔离，当基础数据结构改变时，需要同时维护路由和 Runner，耦合严重。

## 改进内容 (What)
- 将涉及 `tasks`（任务）、`events`（事件）和 `focus_logs`（专注记录）的 SQL 查询抽离到专门的 `backend/services/todo_service.py` 中。
- 将涉及每日论文数据（candidates）的 SQL 查询抽离到 `backend/services/arxiv_service.py` 中。
- 重构了 `assistant_runner.py` 中的内置工具调用，改为直接调用抽象好的 Service 接口。

## 验证 (Validation)
- 运行了 `uv run ruff check` 和 `uv run ruff format`，确保代码规范。
- 成功执行 `uv run pytest`，所有后端测试全部通过，保证了行为逻辑的向后兼容和完全一致。

## 风险评估 (Risks)
- 低风险（没有改变任何对外提供的数据签名和接口行为，相关的模拟测试也全部通过）。