### PR TITLE
feat(todo): 番茄钟三态工作流（focus/rest/normal）

### DIFF
--- a/backend/routes/todo_routes.py
+++ b/backend/routes/todo_routes.py
@@ -14,6 +14,10 @@ router = APIRouter(prefix="/todo", tags=["todo"])
 
 TaskStatus = Literal["todo", "done"]
 TaskCyclePeriod = Literal["daily", "weekly", "monthly", "custom"]
+PomodoroStatus = Literal["normal", "focus", "rest"]
+
+FOCUS_MAX_SECONDS = 25 * 60
+REST_MAX_SECONDS = 5 * 60
 
 
 class TaskCreateRequest(BaseModel):
@@ -106,6 +110,25 @@ class FocusLogOut(BaseModel):
     start_time: datetime
     end_at: datetime | None
     created_at: datetime
+    pomodoro_status: PomodoroStatus = "focus"
+    limit_seconds: int | None = None
+    remaining_seconds: int | None = None
+    requires_confirmation: bool = False
+
+
+class PomodoroCurrentOut(BaseModel):
+    status: PomodoroStatus
+    workflow_task_id: UUID | None = None
+    current_task_id: UUID | None = None
+    started_at: datetime | None = None
+    elapsed_seconds: int = 0
+    limit_seconds: int | None = None
+    remaining_seconds: int | None = None
+    requires_confirmation: bool = False
+
+
+class PomodoroAdvanceRequest(BaseModel):
+    task_id: UUID | None = None
 
 
 class FocusTodayOut(BaseModel):
@@ -226,6 +249,31 @@ async def init_todo(app: Any) -> None:
             );
             """
         )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rest_logs (
+              id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+              user_id BIGINT NOT NULL REFERENCES auth_users(id) ON DELETE CASCADE,
+              duration INTEGER NOT NULL,
+              start_time TIMESTAMPTZ NOT NULL,
+              end_at TIMESTAMPTZ NULL,
+              created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              CONSTRAINT chk_rest_logs_duration CHECK (duration >= 0),
+              CONSTRAINT chk_rest_logs_end_at CHECK (end_at IS NULL OR end_at >= start_time)
+            );
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pomodoro_state (
+              user_id BIGINT PRIMARY KEY REFERENCES auth_users(id) ON DELETE CASCADE,
+              current_status VARCHAR(20) NOT NULL DEFAULT 'normal',
+              workflow_task_id UUID NULL REFERENCES tasks(id) ON DELETE SET NULL,
+              updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+              CONSTRAINT chk_pomodoro_current_status CHECK (current_status IN ('normal', 'focus', 'rest'))
+            );
+            """
+        )
 
         await conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_tasks_user_deleted_status ON tasks(user_id, is_deleted, status);"
@@ -245,6 +293,12 @@ async def init_todo(app: Any) -> None:
         await conn.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS uniq_focus_open_per_user ON focus_logs(user_id) WHERE end_at IS NULL;"
         )
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_rest_logs_user_start ON rest_logs(user_id, start_time DESC);"
+        )
+        await conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uniq_rest_open_per_user ON rest_logs(user_id) WHERE end_at IS NULL;"
+        )
         # 迁移：允许 end_at 为空、放宽 duration 校验并更新时间一致性约束
         await conn.execute("ALTER TABLE focus_logs ALTER COLUMN end_at DROP NOT NULL;")
         await conn.execute("ALTER TABLE focus_logs DROP CONSTRAINT IF EXISTS chk_focus_logs_duration;")
@@ -252,6 +306,13 @@ async def init_todo(app: Any) -> None:
         await conn.execute("ALTER TABLE focus_logs ADD CONSTRAINT chk_focus_logs_duration CHECK (duration >= 0);")
         await conn.execute(
             "ALTER TABLE focus_logs ADD CONSTRAINT chk_focus_logs_end_at CHECK (end_at IS NULL OR end_at >= start_time);"
+        )
+        await conn.execute("ALTER TABLE rest_logs ALTER COLUMN end_at DROP NOT NULL;")
+        await conn.execute("ALTER TABLE rest_logs DROP CONSTRAINT IF EXISTS chk_rest_logs_duration;")
+        await conn.execute("ALTER TABLE rest_logs DROP CONSTRAINT IF EXISTS chk_rest_logs_end_at;")
+        await conn.execute("ALTER TABLE rest_logs ADD CONSTRAINT chk_rest_logs_duration CHECK (duration >= 0);")
+        await conn.execute(
+            "ALTER TABLE rest_logs ADD CONSTRAINT chk_rest_logs_end_at CHECK (end_at IS NULL OR end_at >= start_time);"
         )
         await conn.execute(
             """
@@ -314,12 +375,27 @@ def _row_to_event(row: asyncpg.Record) -> EventOut:
     )
 
 
-def _row_to_focus_log(row: asyncpg.Record) -> FocusLogOut:
+def _row_to_focus_log(
+    row: asyncpg.Record,
+    *,
+    limit_seconds: int | None = None,
+    pomodoro_status: PomodoroStatus = "focus",
+) -> FocusLogOut:
     """将 asyncpg.Record 转为 FocusLogOut。"""
     # 当 end_at 为空表示进行中的专注，动态计算到当前的持续时长
     _dynamic_duration = (
         int((datetime.now(UTC) - row["start_time"]).total_seconds()) if row["end_at"] is None else int(row["duration"])
     )
+    if _dynamic_duration < 0:
+        _dynamic_duration = 0
+    remaining_seconds: int | None = None
+    requires_confirmation = False
+    if limit_seconds is not None:
+        if _dynamic_duration > limit_seconds:
+            _dynamic_duration = limit_seconds
+        if row["end_at"] is None:
+            remaining_seconds = max(limit_seconds - _dynamic_duration, 0)
+            requires_confirmation = _dynamic_duration >= limit_seconds
     return FocusLogOut(
         id=row["id"],
         user_id=int(row["user_id"]),
@@ -328,6 +404,32 @@ def _row_to_focus_log(row: asyncpg.Record) -> FocusLogOut:
         start_time=row["start_time"],
         end_at=row["end_at"],
         created_at=row["created_at"],
+        pomodoro_status=pomodoro_status,
+        limit_seconds=limit_seconds,
+        remaining_seconds=remaining_seconds,
+        requires_confirmation=requires_confirmation,
+    )
+
+
+async def _upsert_pomodoro_state(
+    conn: asyncpg.Connection,
+    user_id: int,
+    *,
+    status_: PomodoroStatus,
+    workflow_task_id: UUID | None,
+) -> None:
+    await conn.execute(
+        """
+        INSERT INTO pomodoro_state(user_id, current_status, workflow_task_id, updated_at)
+        VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (user_id)
+        DO UPDATE SET current_status = EXCLUDED.current_status,
+                      workflow_task_id = EXCLUDED.workflow_task_id,
+                      updated_at = NOW()
+        """,
+        int(user_id),
+        status_,
+        workflow_task_id,
     )
 
 
@@ -806,6 +908,16 @@ async def start_focus(
             )
             if task_row is None:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="任务不存在")
+            open_rest = await conn.fetchrow(
+                """
+                SELECT id
+                FROM rest_logs
+                WHERE user_id = $1 AND end_at IS NULL
+                """,
+                int(user.id),
+            )
+            if open_rest is not None:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="已有进行中的休息")
             try:
                 row = await conn.fetchrow(
                     """
@@ -818,9 +930,10 @@ async def start_focus(
                 )
             except asyncpg.UniqueViolationError:
                 raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="已有进行中的专注")
+            await _upsert_pomodoro_state(conn, int(user.id), status_="focus", workflow_task_id=task_id)
     if row is None:
         raise HTTPException(status_code=500, detail="开始专注失败")
-    return _row_to_focus_log(row)
+    return _row_to_focus_log(row, limit_seconds=FOCUS_MAX_SECONDS, pomodoro_status="focus")
 
 
 @router.post("/focus/stop", response_model=FocusLogOut)
@@ -845,8 +958,9 @@ async def stop_focus(
             now = datetime.now(UTC)
             start = open_row["start_time"]
             dur = int((now - start).total_seconds())
-            if dur < 0:
-                dur = 0
+            dur = max(dur, 0)
+            if dur > FOCUS_MAX_SECONDS:
+                dur = FOCUS_MAX_SECONDS
             row = await conn.fetchrow(
                 """
                 UPDATE focus_logs
@@ -867,9 +981,176 @@ async def stop_focus(
                 row["task_id"],
                 int(user.id),
             )
+            await _upsert_pomodoro_state(conn, int(user.id), status_="normal", workflow_task_id=None)
     if row is None:
         raise HTTPException(status_code=500, detail="结束专注失败")
-    return _row_to_focus_log(row)
+    return _row_to_focus_log(row, limit_seconds=FOCUS_MAX_SECONDS, pomodoro_status="focus")
+
+
+@router.post("/break/stop", response_model=PomodoroCurrentOut)
+async def stop_break(
+    request: Request,
+    user: Annotated[Any, Depends(get_current_user)],
+) -> PomodoroCurrentOut:
+    """结束休息并回到普通状态。"""
+    pool = _pool_from_request(request)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            rest_row = await conn.fetchrow(
+                """
+                SELECT id, start_time
+                FROM rest_logs
+                WHERE user_id = $1 AND end_at IS NULL
+                """,
+                int(user.id),
+            )
+            if rest_row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="当前无进行中的休息")
+            dur = int((datetime.now(UTC) - rest_row["start_time"]).total_seconds())
+            dur = max(dur, 0)
+            if dur > REST_MAX_SECONDS:
+                dur = REST_MAX_SECONDS
+            await conn.execute(
+                """
+                UPDATE rest_logs
+                SET end_at = NOW(), duration = $1
+                WHERE id = $2
+                """,
+                dur,
+                rest_row["id"],
+            )
+            await _upsert_pomodoro_state(conn, int(user.id), status_="normal", workflow_task_id=None)
+    return PomodoroCurrentOut(status="normal")
+
+
+@router.post("/pomodoro/advance", response_model=PomodoroCurrentOut)
+async def advance_pomodoro(
+    request: Request,
+    body: PomodoroAdvanceRequest,
+    user: Annotated[Any, Depends(get_current_user)],
+) -> PomodoroCurrentOut:
+    """在达到时长上限后推进番茄钟状态：专注->休息 或 休息->专注。"""
+    pool = _pool_from_request(request)
+    uid = int(user.id)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            focus_row = await conn.fetchrow(
+                """
+                SELECT id, task_id, start_time
+                FROM focus_logs
+                WHERE user_id = $1 AND end_at IS NULL
+                """,
+                uid,
+            )
+            if focus_row is not None:
+                focus_elapsed = int((datetime.now(UTC) - focus_row["start_time"]).total_seconds())
+                focus_elapsed = max(focus_elapsed, 0)
+                if focus_elapsed < FOCUS_MAX_SECONDS:
+                    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="当前专注尚未达到上限")
+                await conn.execute(
+                    """
+                    UPDATE focus_logs
+                    SET end_at = NOW(), duration = $1
+                    WHERE id = $2
+                    """,
+                    FOCUS_MAX_SECONDS,
+                    focus_row["id"],
+                )
+                await conn.execute(
+                    """
+                    UPDATE tasks
+                    SET actual_duration = actual_duration + $1, updated_at = NOW()
+                    WHERE id = $2 AND user_id = $3 AND is_deleted = FALSE
+                    """,
+                    FOCUS_MAX_SECONDS,
+                    focus_row["task_id"],
+                    uid,
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO rest_logs(user_id, duration, start_time, end_at)
+                    VALUES ($1, 0, NOW(), NULL)
+                    """,
+                    uid,
+                )
+                await _upsert_pomodoro_state(conn, uid, status_="rest", workflow_task_id=focus_row["task_id"])
+                return PomodoroCurrentOut(
+                    status="rest",
+                    workflow_task_id=focus_row["task_id"],
+                    started_at=datetime.now(UTC),
+                    elapsed_seconds=0,
+                    limit_seconds=REST_MAX_SECONDS,
+                    remaining_seconds=REST_MAX_SECONDS,
+                    requires_confirmation=False,
+                )
+
+            rest_row = await conn.fetchrow(
+                """
+                SELECT id, start_time
+                FROM rest_logs
+                WHERE user_id = $1 AND end_at IS NULL
+                """,
+                uid,
+            )
+            if rest_row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="当前不在可推进的番茄钟状态")
+            rest_elapsed = int((datetime.now(UTC) - rest_row["start_time"]).total_seconds())
+            rest_elapsed = max(rest_elapsed, 0)
+            if rest_elapsed < REST_MAX_SECONDS:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="当前休息尚未达到上限")
+            state_row = await conn.fetchrow(
+                """
+                SELECT workflow_task_id
+                FROM pomodoro_state
+                WHERE user_id = $1
+                """,
+                uid,
+            )
+            next_task_id = body.task_id or ((state_row or {}).get("workflow_task_id"))
+            if next_task_id is None:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="缺少下一轮专注任务")
+            task_row = await conn.fetchrow(
+                """
+                SELECT id
+                FROM tasks
+                WHERE id = $1 AND user_id = $2 AND is_deleted = FALSE AND status <> 'done'
+                """,
+                next_task_id,
+                uid,
+            )
+            if task_row is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="下一轮专注任务不存在")
+            await conn.execute(
+                """
+                UPDATE rest_logs
+                SET end_at = NOW(), duration = $1
+                WHERE id = $2
+                """,
+                REST_MAX_SECONDS,
+                rest_row["id"],
+            )
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO focus_logs(user_id, task_id, duration, start_time, end_at)
+                    VALUES ($1, $2, 0, NOW(), NULL)
+                    """,
+                    uid,
+                    next_task_id,
+                )
+            except asyncpg.UniqueViolationError:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="已有进行中的专注")
+            await _upsert_pomodoro_state(conn, uid, status_="focus", workflow_task_id=next_task_id)
+            return PomodoroCurrentOut(
+                status="focus",
+                workflow_task_id=next_task_id,
+                current_task_id=next_task_id,
+                started_at=datetime.now(UTC),
+                elapsed_seconds=0,
+                limit_seconds=FOCUS_MAX_SECONDS,
+                remaining_seconds=FOCUS_MAX_SECONDS,
+                requires_confirmation=False,
+            )
 
 
 @router.get("/focus/current", response_model=FocusLogOut)
@@ -890,7 +1171,72 @@ async def get_current_focus(
         )
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="当前无进行中的专注")
-    return _row_to_focus_log(row)
+    return _row_to_focus_log(row, limit_seconds=FOCUS_MAX_SECONDS, pomodoro_status="focus")
+
+
+@router.get("/pomodoro/current", response_model=PomodoroCurrentOut)
+async def get_current_pomodoro(
+    request: Request,
+    user: Annotated[Any, Depends(get_current_user)],
+) -> PomodoroCurrentOut:
+    """查询当前番茄钟状态（普通/专注/休息）。"""
+    uid = int(user.id)
+    pool = _pool_from_request(request)
+    async with pool.acquire() as conn:
+        focus_row = await conn.fetchrow(
+            """
+            SELECT task_id, start_time
+            FROM focus_logs
+            WHERE user_id = $1 AND end_at IS NULL
+            """,
+            uid,
+        )
+        if focus_row is not None:
+            elapsed = int((datetime.now(UTC) - focus_row["start_time"]).total_seconds())
+            elapsed = max(elapsed, 0)
+            elapsed = min(elapsed, FOCUS_MAX_SECONDS)
+            return PomodoroCurrentOut(
+                status="focus",
+                workflow_task_id=focus_row["task_id"],
+                current_task_id=focus_row["task_id"],
+                started_at=focus_row["start_time"],
+                elapsed_seconds=elapsed,
+                limit_seconds=FOCUS_MAX_SECONDS,
+                remaining_seconds=max(FOCUS_MAX_SECONDS - elapsed, 0),
+                requires_confirmation=elapsed >= FOCUS_MAX_SECONDS,
+            )
+
+        rest_row = await conn.fetchrow(
+            """
+            SELECT start_time
+            FROM rest_logs
+            WHERE user_id = $1 AND end_at IS NULL
+            """,
+            uid,
+        )
+        state_row = await conn.fetchrow(
+            """
+            SELECT workflow_task_id
+            FROM pomodoro_state
+            WHERE user_id = $1
+            """,
+            uid,
+        )
+        workflow_task_id = (state_row or {}).get("workflow_task_id")
+        if rest_row is not None:
+            elapsed = int((datetime.now(UTC) - rest_row["start_time"]).total_seconds())
+            elapsed = max(elapsed, 0)
+            elapsed = min(elapsed, REST_MAX_SECONDS)
+            return PomodoroCurrentOut(
+                status="rest",
+                workflow_task_id=workflow_task_id,
+                started_at=rest_row["start_time"],
+                elapsed_seconds=elapsed,
+                limit_seconds=REST_MAX_SECONDS,
+                remaining_seconds=max(REST_MAX_SECONDS - elapsed, 0),
+                requires_confirmation=elapsed >= REST_MAX_SECONDS,
+            )
+        return PomodoroCurrentOut(status="normal", workflow_task_id=workflow_task_id)
 
 
 @router.get("/focus/today", response_model=FocusTodayOut)
@@ -914,7 +1260,7 @@ async def get_today_focus_duration(
                     0,
                     EXTRACT(
                       epoch FROM (
-                        LEAST(COALESCE(fl.end_at, NOW()), b.day_end)
+                        LEAST(COALESCE(fl.end_at, NOW()), b.day_end, fl.start_time + ($2 * INTERVAL '1 second'))
                         - GREATEST(fl.start_time, b.day_start)
                       )
                     )
@@ -929,6 +1275,7 @@ async def get_today_focus_duration(
               AND COALESCE(fl.end_at, NOW()) > b.day_start
             """,
             int(user.id),
+            FOCUS_MAX_SECONDS,
         )
     seconds = int((row or {}).get("seconds") or 0)
     if seconds < 0:
@@ -969,7 +1316,11 @@ async def get_focus_stats(
                         0,
                         EXTRACT(
                             epoch FROM (
-                                LEAST(COALESCE(fl.end_at, NOW()), b.range_end)
+                                LEAST(
+                                    COALESCE(fl.end_at, NOW()),
+                                    b.range_end,
+                                    fl.start_time + ($3 * INTERVAL '1 second')
+                                )
                                 - GREATEST(fl.start_time, b.range_start)
                             )
                         )
@@ -992,6 +1343,7 @@ async def get_focus_stats(
             """,
             int(user.id),
             range_start,
+            FOCUS_MAX_SECONDS,
         )
 
     tasks_stats = [

--- a/backend/services/todo_service.py
+++ b/backend/services/todo_service.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
 from typing import Any
 
+FOCUS_MAX_SECONDS = 25 * 60
+
 
 async def get_today_tasks(pool: Any, user_id: int) -> list[dict[str, Any]]:
     async with pool.acquire() as conn:
@@ -93,6 +95,8 @@ async def get_focus_current(pool: Any, user_id: int) -> dict[str, Any]:
         dur = int((datetime.now(UTC) - row["start_time"]).total_seconds())
         if dur < 0:
             dur = 0
+        if dur > FOCUS_MAX_SECONDS:
+            dur = FOCUS_MAX_SECONDS
         task_row = await conn.fetchrow(
             """
             SELECT id, title, status

--- a/backend/tests/test_todo_routes.py
+++ b/backend/tests/test_todo_routes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
@@ -34,6 +34,9 @@ class _FakeTodoConn:
     def __init__(self) -> None:
         self.stats_rows: list[dict[str, Any]] = []
         self.events: list[dict[str, Any]] = []
+        self.open_focus_row: dict[str, Any] | None = None
+        self.open_rest_row: dict[str, Any] | None = None
+        self.pomodoro_state_row: dict[str, Any] | None = None
 
     async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
         if "WITH bounds AS" in sql and "FROM log_durations ld" in sql:
@@ -48,6 +51,12 @@ class _FakeTodoConn:
         return []
 
     async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any] | None:
+        if "FROM focus_logs" in sql and "end_at IS NULL" in sql:
+            return self.open_focus_row
+        if "FROM rest_logs" in sql and "end_at IS NULL" in sql:
+            return self.open_rest_row
+        if "FROM pomodoro_state" in sql:
+            return self.pomodoro_state_row
         if "INSERT INTO events" in sql:
             event_id = uuid4()
             now = datetime.now(UTC)
@@ -188,6 +197,53 @@ def test_get_focus_stats_invalid_range(monkeypatch) -> None:
 
     resp = client.get("/todo/focus/stats?range=year")
     assert resp.status_code == 422
+
+
+def test_get_current_focus_caps_duration(monkeypatch) -> None:
+    conn = _FakeTodoConn()
+    now = datetime.now(UTC)
+    conn.open_focus_row = {
+        "id": uuid4(),
+        "user_id": 7,
+        "task_id": uuid4(),
+        "duration": 0,
+        "start_time": now - timedelta(minutes=40),
+        "end_at": None,
+        "created_at": now,
+    }
+    pool = _FakePool(conn)
+    monkeypatch.setattr("routes.todo_routes._pool_from_request", lambda _: pool)
+
+    app = _build_app()
+    client = TestClient(app)
+
+    resp = client.get("/todo/focus/current")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["duration"] == 1500
+    assert data["limit_seconds"] == 1500
+    assert data["remaining_seconds"] == 0
+    assert data["requires_confirmation"] is True
+
+
+def test_get_current_pomodoro_rest_requires_confirmation(monkeypatch) -> None:
+    conn = _FakeTodoConn()
+    task_id = uuid4()
+    conn.open_rest_row = {"start_time": datetime.now(UTC) - timedelta(minutes=8)}
+    conn.pomodoro_state_row = {"workflow_task_id": task_id}
+    pool = _FakePool(conn)
+    monkeypatch.setattr("routes.todo_routes._pool_from_request", lambda _: pool)
+
+    app = _build_app()
+    client = TestClient(app)
+
+    resp = client.get("/todo/pomodoro/current")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "rest"
+    assert data["workflow_task_id"] == str(task_id)
+    assert data["requires_confirmation"] is True
+    assert data["remaining_seconds"] == 0
 
 
 def test_create_event_can_be_primary(monkeypatch) -> None:

--- a/frontend/src/components/PlaceholderCard.tsx
+++ b/frontend/src/components/PlaceholderCard.tsx
@@ -30,11 +30,17 @@ interface PlaceholderCardProps {
   split?: number;
 }
 
-interface FocusSession {
-  id: string;
-  task_id: string;
-  start_time: string;
-  duration: number;
+type PomodoroStatus = 'normal' | 'focus' | 'rest';
+
+interface PomodoroCurrent {
+  status: PomodoroStatus;
+  workflow_task_id: string | null;
+  current_task_id: string | null;
+  started_at: string | null;
+  elapsed_seconds: number;
+  limit_seconds: number | null;
+  remaining_seconds: number | null;
+  requires_confirmation: boolean;
 }
 
 interface TodayFocusSummary {
@@ -82,7 +88,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   const navigate = useNavigate();
 
   // Focus State
-  const [currentFocus, setCurrentFocus] = useState<FocusSession | null>(null);
+  const [pomodoroCurrent, setPomodoroCurrent] = useState<PomodoroCurrent | null>(null);
   const [focusDurationStr, setFocusDurationStr] = useState('0min');
   const [todayFocusMinutes, setTodayFocusMinutes] = useState(0);
   const [showFocusTaskPicker, setShowFocusTaskPicker] = useState(false);
@@ -140,16 +146,21 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
 
   // Update focus duration timer
   useEffect(() => {
-    if (!currentFocus) {
+    if (!pomodoroCurrent || pomodoroCurrent.status === 'normal' || !pomodoroCurrent.started_at) {
       setFocusDurationStr('0min');
       return;
     }
 
     const updateDuration = () => {
       // 更新当前任务专注时长
-      const start = new Date(currentFocus.start_time).getTime();
+      const start = new Date(pomodoroCurrent.started_at).getTime();
       const now = new Date().getTime();
-      const diffMinutes = Math.floor((now - start) / 60000);
+      const diffSecondsRaw = Math.floor((now - start) / 1000);
+      const diffSecondsSafe = diffSecondsRaw < 0 ? 0 : diffSecondsRaw;
+      const limited = pomodoroCurrent.limit_seconds
+        ? Math.min(diffSecondsSafe, pomodoroCurrent.limit_seconds)
+        : diffSecondsSafe;
+      const diffMinutes = Math.floor(limited / 60);
       setFocusDurationStr(`${diffMinutes}min`);
       
       // 同时刷新今日专注总时长，保持同步
@@ -159,7 +170,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
     updateDuration();
     const timer = setInterval(updateDuration, 60000); // Update every minute
     return () => clearInterval(timer);
-  }, [currentFocus]);
+  }, [pomodoroCurrent]);
 
   useEffect(() => {
     if (showTaskModal && activeTab === 'all') {
@@ -313,11 +324,10 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
 
   async function _loadCurrentFocus() {
     try {
-      const res = await apiJson('/todo/focus/current');
-      setCurrentFocus(res as FocusSession);
+      const res = await apiJson('/todo/pomodoro/current');
+      setPomodoroCurrent(res as PomodoroCurrent);
     } catch {
-      // 404 means no focus, which is fine
-      setCurrentFocus(null);
+      setPomodoroCurrent(null);
     }
   }
 
@@ -335,8 +345,17 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
       const res = await apiJson(`/todo/tasks/${taskId}/focus/start`, {
         method: 'POST'
       });
-      setCurrentFocus(res as FocusSession);
-      _loadTasks(); // Reload tasks to update UI if needed
+      setPomodoroCurrent({
+        status: 'focus',
+        workflow_task_id: (res as { task_id: string }).task_id,
+        current_task_id: (res as { task_id: string }).task_id,
+        started_at: (res as { start_time: string }).start_time,
+        elapsed_seconds: 0,
+        limit_seconds: (res as { limit_seconds?: number }).limit_seconds ?? 1500,
+        remaining_seconds: (res as { remaining_seconds?: number }).remaining_seconds ?? 1500,
+        requires_confirmation: false,
+      });
+      _loadTasks();
     } catch (e) {
       console.error('Failed to start focus', e);
       alert('开始专注失败');
@@ -348,10 +367,39 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
       await apiJson('/todo/focus/stop', {
         method: 'POST'
       });
-      setCurrentFocus(null);
-      _loadTasks();
+      setPomodoroCurrent({ status: 'normal', workflow_task_id: null, current_task_id: null, started_at: null, elapsed_seconds: 0, limit_seconds: null, remaining_seconds: null, requires_confirmation: false });
+      await Promise.all([_loadTasks(), _loadCurrentFocus(), _loadTodayFocus()]);
     } catch (e) {
       console.error('Failed to stop focus', e);
+    }
+  }
+
+  async function _stopBreak() {
+    try {
+      await apiJson('/todo/break/stop', {
+        method: 'POST'
+      });
+      setPomodoroCurrent({ status: 'normal', workflow_task_id: null, current_task_id: null, started_at: null, elapsed_seconds: 0, limit_seconds: null, remaining_seconds: null, requires_confirmation: false });
+      await _loadCurrentFocus();
+    } catch (e) {
+      console.error('Failed to stop break', e);
+      alert('结束休息失败');
+    }
+  }
+
+  async function _advancePomodoro() {
+    try {
+      const res = await apiJson('/todo/pomodoro/advance', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      setPomodoroCurrent(res as PomodoroCurrent);
+      await Promise.all([_loadTasks(), _loadCurrentFocus(), _loadTodayFocus()]);
+    } catch (e) {
+      console.error('Failed to advance pomodoro', e);
+      const msg = e instanceof Error ? e.message : '推进番茄钟状态失败';
+      alert(msg);
     }
   }
 
@@ -610,39 +658,37 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   async function _handleFocusToggle(e: React.MouseEvent) {
     e.stopPropagation();
     
-    // 如果当前正在专注，则停止
-    if (currentFocus) {
+    const status = pomodoroCurrent?.status ?? 'normal';
+    if (status === 'focus') {
+      if (pomodoroCurrent?.requires_confirmation) {
+        if (confirm('本轮专注已达上限，是否进入休息？')) {
+          await _advancePomodoro();
+        }
+        return;
+      }
+      if (confirm('是否结束当前专注并回到普通状态？')) {
+        await _stopFocus();
+      }
+      return;
+    }
+
+    if (status === 'rest') {
+      if (pomodoroCurrent?.requires_confirmation) {
+        if (confirm('本轮休息已达上限，是否开始下一轮专注？')) {
+          await _advancePomodoro();
+        }
+      } else if (confirm('是否提前结束休息并回到普通状态？')) {
+        await _stopBreak();
+      }
+      return;
+    }
+
+    // 普通状态 -> 开始专注
+    if (status === 'normal') {
       // 简单的停止逻辑，或者根据需求：如果点击的是同一个任务则停止，不同任务则切换？
       // 这里的 UI 是全局的“专注状态”，所以点击意味着结束当前专注。
       // 但是根据用户需求 1: "检查...是否是即将要专注的特定任务...是则跳转第二步(开始专注?)...否则提示...然后跳转第二步"
       // 这意味着点击这个 div 总是倾向于 "开始专注目标任务"。
-      
-      const targetTask = _pickTodayFocusTask();
-      
-      // 如果没有目标任务，但当前有专注，点击应该是停止？
-      if (!targetTask) {
-        if (confirm('当前无今日待办任务，是否结束当前专注？')) {
-          await _stopFocus();
-        }
-        return;
-      }
-
-      // 如果当前专注的就是目标任务 -> 用户可能是想停止？
-      // 但用户需求说：
-      // "该 div 的悬停状态下显示的文字 由 开始专注 变成结束专注... 任务名称则变为正在专注的任务"
-      // 这意味着如果已经专注，UI 显示为“结束专注”，点击它应该执行“结束专注”的操作。
-      
-      if (currentFocus.task_id === targetTask.id) {
-         await _stopFocus();
-         return;
-      }
-
-      // 如果当前专注的不是目标任务 -> 切换
-      alert('正在专注其他任务，将为您切换到新任务');
-      await _stopFocus();
-      await _startFocus(targetTask.id);
-    } else {
-      // 当前无专注 -> 开始专注目标任务
       const targetTask = _pickTodayFocusTask();
       if (targetTask) {
         await _startFocus(targetTask.id);
@@ -661,7 +707,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
   async function _handleCompleteAndStopFocus(e: React.MouseEvent) {
     e.stopPropagation();
     if (focusQuickActionBusy) return;
-    const targetTaskId = currentFocus?.task_id ?? _pickTodayFocusTask()?.id ?? null;
+    const targetTaskId = pomodoroCurrent?.current_task_id ?? _pickTodayFocusTask()?.id ?? null;
     if (!targetTaskId) {
       alert('没有可完成的即将专注任务');
       return;
@@ -673,9 +719,9 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'done' }),
       });
-      if (currentFocus?.task_id === targetTaskId) {
+      if (pomodoroCurrent?.status === 'focus' && pomodoroCurrent.current_task_id === targetTaskId) {
         await apiJson('/todo/focus/stop', { method: 'POST' });
-        setCurrentFocus(null);
+        setPomodoroCurrent({ status: 'normal', workflow_task_id: null, current_task_id: null, started_at: null, elapsed_seconds: 0, limit_seconds: null, remaining_seconds: null, requires_confirmation: false });
       }
       setFocusTargetTaskId((prev) => (prev === targetTaskId ? null : prev));
       await Promise.all([_loadTasks(), _loadCurrentFocus(), _loadTodayFocus()]);
@@ -807,11 +853,23 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
 
   if (index === 0) {
     const targetTask = _pickTodayFocusTask();
-    const isFocusing = !!currentFocus;
-    // 如果正在专注，显示正在专注的任务名；否则显示即将专注的任务名
-    const displayTaskTitle = isFocusing 
-      ? tasks.find(t => t.id === currentFocus.task_id)?.title || '未知任务'
-      : targetTask?.title || '无计划';
+    const status = pomodoroCurrent?.status ?? 'normal';
+    const isFocusing = status === 'focus';
+    const isResting = status === 'rest';
+    const activeTaskId = pomodoroCurrent?.current_task_id ?? null;
+    const workflowTaskId = pomodoroCurrent?.workflow_task_id ?? null;
+    const displayTaskTitle = isFocusing
+      ? tasks.find(t => t.id === activeTaskId)?.title || '未知任务'
+      : isResting
+        ? tasks.find(t => t.id === workflowTaskId)?.title || '休息中'
+        : targetTask?.title || '无计划';
+    const hoverActionText = isFocusing
+      ? (pomodoroCurrent?.requires_confirmation ? '进入休息' : '结束专注')
+      : isResting
+        ? (pomodoroCurrent?.requires_confirmation ? '开始下一轮专注' : '结束休息')
+        : '开始专注';
+    const hoverStatusLabel = isFocusing ? '正在专注于：' : isResting ? '休息中（任务）：' : '即将专注于：';
+    const showDuration = isFocusing || isResting;
 
     return (
       <>
@@ -819,7 +877,7 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
           <div className="flex-[2] flex flex-col rounded overflow-hidden">
             <div 
               className={`group relative flex-[2] bg-white/5 flex items-center justify-center hover:bg-white/10 transition-colors cursor-pointer ${
-                isFocusing ? 'bg-blue-500/10 border border-blue-500/20' : ''
+                isFocusing ? 'bg-blue-500/10 border border-blue-500/20' : isResting ? 'bg-emerald-500/10 border border-emerald-500/20' : ''
               }`}
               onClick={_handleFocusToggle}
             >
@@ -850,16 +908,16 @@ const PlaceholderCard: React.FC<PlaceholderCardProps> = ({ index, split = 1 }) =
               </button>
 
               <span className={`text-4xl font-bold group-hover:opacity-0 transition-opacity duration-300 ${
-                isFocusing ? 'text-blue-400' : ''
+                isFocusing ? 'text-blue-400' : isResting ? 'text-emerald-300' : ''
               }`}>
-                {isFocusing ? focusDurationStr : `${todayFocusMinutes}min`}
+                {showDuration ? focusDurationStr : `${todayFocusMinutes}min`}
               </span>
               <div className="absolute inset-0 flex flex-col items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                 <span className="text-2xl font-bold">
-                  {isFocusing ? '结束专注' : '开始专注'}
+                  {hoverActionText}
                 </span>
                 <span className="text-sm text-white/60 mt-1">
-                  {isFocusing ? '正在专注于：' : '即将专注于：'}
+                  {hoverStatusLabel}
                   {displayTaskTitle}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- 为专注系统引入 normal / focus / rest 三态与番茄钟推进接口
- 新增休息持久化（rest_logs）与当前状态持久化（pomodoro_state）
- 为专注与休息增加单次上限，并在到达上限后仅在用户确认时推进到下一状态
- 更新前端 PlaceholderCard 交互，接入 pomodoro current/advance 与休息态展示
- 保持现有 /todo/focus/* 接口可用，并对时长进行上限裁剪防止忘记停止导致时长失真

## Test Evidence
- backend: 
- backend: 
- frontend:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/private/tmp/ark-issue48".
- frontend:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/private/tmp/ark-issue48".（仅有仓库已有 warning）
- frontend:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/private/tmp/ark-issue48".
- frontend:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/private/tmp/ark-issue48".

Closes #48